### PR TITLE
bump down  version to v0.4.8 from crates.io

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,16 +24,17 @@ slog-term = "2.4"
 
 # Network-specific
 futures = "0.1.2"
-tokio = "0.1.7"
+
+[dependencies.tokio]
+git = "https://github.com/jarlopez/tokio"
+branch = "bytes-v0.4.8-migration"
 
 [dependencies.bytes]
-git = "https://github.com/carllerche/bytes"
-branch = "master"
+version = "0.4.8"
 
 [dependencies.spaniel]
 git = "https://github.com/jarlopez/spaniel"
 branch = "master"
-#path = "../../spaniel/"
 
 [dev-dependencies]
 #env_logger = "0.4"

--- a/core/src/default_serialisers.rs
+++ b/core/src/default_serialisers.rs
@@ -31,7 +31,7 @@ impl Serialisable for u64 {
         Some(8)
     }
     fn serialise(&self, buf: &mut BufMut) -> Result<(), SerError> {
-        buf.put_u64(*self);
+        buf.put_u64_be(*self);
         Ok(())
     }
     fn local(self: Box<Self>) -> Result<Box<Any + Send>, Box<Serialisable>> {

--- a/core/src/serialisation.rs
+++ b/core/src/serialisation.rs
@@ -212,7 +212,7 @@ pub mod helpers {
 
         let (mut buffer, src) = deserialise_actor_path(&mut buffer, system)?;
         let (buffer, dst) = deserialise_actor_path(&mut buffer, system)?;
-        let ser_id: u64 = buffer.get_u64();
+        let ser_id: u64 = buffer.get_u64_be();
         let data = buffer.bytes().into();
 
         let envelope = ReceiveEnvelope::Msg {
@@ -270,17 +270,16 @@ mod tests {
             Some(88)
         }
         fn serialise(&self, v: &Test1, buf: &mut BufMut) -> Result<(), SerError> {
-            //buf.put_u64::<BigEndian>(v.i);
-            buf.put_u64(v.i);
+            buf.put_u64_be(v.i);
             for i in 0..10 {
-                buf.put_u64(i);
+                buf.put_u64_be(i);
             }
             Result::Ok(())
         }
     }
     impl Deserialiser<Test1> for T1Ser {
         fn deserialise(buf: &mut Buf) -> Result<Test1, SerError> {
-            let i = buf.get_u64();
+            let i = buf.get_u64_be();
             Result::Ok(Test1 { i })
         }
     }


### PR DESCRIPTION
This single-commit PR integrates with a forked `tokio` repository which uses `bytes` v0.4.8 across all sub-crates and uses the same version for the kompics project.