### PR TITLE
Futures-oriented, named actor registration

### DIFF
--- a/core/src/actors.rs
+++ b/core/src/actors.rs
@@ -433,6 +433,10 @@ impl NamedPath {
         }
     }
 
+    pub fn with_system(system: SystemPath, path: Vec<String>) -> NamedPath {
+        NamedPath { system, path }
+    }
+
     pub fn path_ref(&self) -> &Vec<String> {
         &self.path
     }

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -64,6 +64,7 @@ impl<T: Send + Sized> Promise<T> {
     pub fn fulfill(self, t: T) {
         self.result_channel
             .send(t)
-            .expect("An error occurred during promise fulfillment!");
+            // ISSUE #12: Explicitly swallow errors
+            .map_err(|_| ());
     }
 }


### PR DESCRIPTION
Registration envelopes now also carry an optional `Promise` which the dispatcher fulfills upon actor registration. If the given `PathResolvable` (whether a unique, aliased, or full actor path) already exists in the actor lookup table, a warning is logged and the `Promise` yields a `RegistrationError::DuplicateEntry`.

*NOTE:* The current supported registration alias is currently only required to be `Into<String>`, not a full `Vec<String>` path like the lookup table supports. 