### PR TITLE
ActorRef cleanup in dispatcher

### DIFF
--- a/core/src/actors.rs
+++ b/core/src/actors.rs
@@ -119,6 +119,11 @@ impl ActorRef {
         });
         self.enqueue(MsgEnvelope::Dispatch(env))
     }
+
+    /// Attempts to upgrade the contained component, returning `true` is possible.
+    pub(crate) fn can_upgrade_component(&self) -> bool {
+        self.component.upgrade().is_some()
+    }
 }
 
 impl ActorRefFactory for ActorRef {
@@ -142,9 +147,7 @@ impl fmt::Display for ActorRef {
 impl PartialEq for ActorRef {
     fn eq(&self, other: &ActorRef) -> bool {
         match (self.component.upgrade(), other.component.upgrade()) {
-            (Some(ref me), Some(ref it)) => {
-                Arc::ptr_eq(me, it)
-            }
+            (Some(ref me), Some(ref it)) => Arc::ptr_eq(me, it),
             _ => false,
         }
     }

--- a/core/src/actors.rs
+++ b/core/src/actors.rs
@@ -16,6 +16,7 @@ use messaging::DispatchEnvelope;
 use messaging::MsgEnvelope;
 use messaging::PathResolvable;
 use messaging::ReceiveEnvelope;
+use std::sync::Arc;
 
 pub trait ActorRaw: ExecuteSend {
     fn receive(&mut self, env: ReceiveEnvelope) -> ();
@@ -135,6 +136,17 @@ impl Debug for ActorRef {
 impl fmt::Display for ActorRef {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "<actor-ref>")
+    }
+}
+
+impl PartialEq for ActorRef {
+    fn eq(&self, other: &ActorRef) -> bool {
+        match (self.component.upgrade(), other.component.upgrade()) {
+            (Some(ref me), Some(ref it)) => {
+                Arc::ptr_eq(me, it)
+            }
+            _ => false,
+        }
     }
 }
 

--- a/core/src/actors.rs
+++ b/core/src/actors.rs
@@ -109,7 +109,7 @@ impl ActorRef {
     }
 
     // TODO figure out a way to have one function match both cases -.-
-    pub fn tell_any<S>(&self, v: Box<Any+Send>, from: &S) -> ()
+    pub fn tell_any<S>(&self, v: Box<Any + Send>, from: &S) -> ()
     where
         S: ActorRefFactory,
     {
@@ -120,7 +120,7 @@ impl ActorRef {
         self.enqueue(MsgEnvelope::Dispatch(env))
     }
 
-    /// Attempts to upgrade the contained component, returning `true` is possible.
+    /// Attempts to upgrade the contained component, returning `true` if possible.
     pub(crate) fn can_upgrade_component(&self) -> bool {
         self.component.upgrade().is_some()
     }

--- a/core/src/component.rs
+++ b/core/src/component.rs
@@ -545,7 +545,7 @@ mod tests {
 
     #[derive(ComponentDefinition, Actor)]
     struct TestComponent {
-        ctx: ComponentContext<TestComponent>
+        ctx: ComponentContext<TestComponent>,
     }
 
     impl TestComponent {

--- a/core/src/dispatch/lookup.rs
+++ b/core/src/dispatch/lookup.rs
@@ -142,8 +142,8 @@ impl ActorLookup for ActorStore {
 
     fn remove(&mut self, actor: ActorRef) -> usize {
         let mut num_deleted = 0;
-        num_deleted += self.remove_from_uuid_map(actor);
-
+        num_deleted += self.remove_from_uuid_map(&actor);
+        num_deleted += self.remove_from_name_map(&actor);
         num_deleted
     }
 
@@ -159,24 +159,33 @@ impl ActorLookup for ActorStore {
 }
 
 impl ActorStore {
-    fn remove_from_uuid_map(&mut self, actor: ActorRef) -> usize {
+    fn remove_from_uuid_map(&mut self, actor: &ActorRef) -> usize {
         let matches: Vec<_> = self.uuid_map
             .iter()
-            .filter(|rec| rec.1 == &actor)
+            .filter(|rec| rec.1 == actor)
             .map(|rec| rec.0.clone())
             .collect();
         let existed = matches.len();
-        for m in matches {
-            self.uuid_map.remove(&m);
-        }
+        for m in matches { self.uuid_map.remove(&m); }
         existed
     }
 
-    fn remove_from_name_map(&mut self, actor: ActorRef) -> usize {
+    fn remove_from_name_map(&mut self, actor: &ActorRef) -> usize {
         // FIXME
-        0
+        let matches: Vec<_> = self.name_map
+            .iter()
+            .filter(|rec| rec.1 == actor)
+            .map(|(key, _)| {
+                // Clone the entire Vec<&String> path to be able to remove entries below
+                let mut cl = Vec::new();
+                for k in key { cl.push(k.clone()); }
+                cl
+            })
+            .collect();
+        let existed = matches.len();
+        for m in matches { self.name_map.remove(&m); }
+        existed
     }
-
 }
 
 impl Clone for ActorStore {

--- a/core/src/dispatch/lookup.rs
+++ b/core/src/dispatch/lookup.rs
@@ -46,8 +46,17 @@ pub trait ActorLookup {
 
 /// Lookup structure for storing and retrieving `ActorRef`s.
 ///
-/// UUID-based references are stored in a `HashMap`, and path-based named references
+/// UUID-based references are stored in a [HashMap], and path-based named references
 /// are stored in a Trie structure.
+///
+/// # Notes
+/// The sequence trie supports the use case of grouping many [ActorRefs] under the same path,
+/// similar to a directory structure. Thus, actors can broadcast to all actors under a certain path
+/// without requiring explicit identifiers for them.
+
+/// Ex: Broadcasting a message to actors stored on the system path "tcp://127.0.0.1:8080/pongers/*"
+///
+/// This use case is not currently being utilized, but it may be in the future.
 pub struct ActorStore {
     uuid_map: HashMap<Uuid, ActorRef>,
     name_map: SequenceTrie<String, ActorRef>,

--- a/core/src/dispatch/lookup/gc.rs
+++ b/core/src/dispatch/lookup/gc.rs
@@ -1,0 +1,139 @@
+use crossbeam::sync::ArcCell;
+use dispatch::lookup::ActorLookup;
+use std::sync::Arc;
+
+mod defaults {
+    use super::FeedbackAlgorithm;
+
+    pub const INITIAL_INTERVAL_MS: u64 = 500;
+    pub const MIN_INTERVAL_MS: u64 = 20;
+    pub const MAX_INTERVAL_MS: u64 = 5_000;
+    pub const ADDITIVE_INCREASE: u64 = 500;
+    pub const MULTIPLICATIVE_DECREASE_NUM: u64 = 1;
+    pub const MULTIPLICATIVE_DECREASE_DEN: u64 = 2;
+    pub const ALGORITHM: FeedbackAlgorithm = super::FeedbackAlgorithm::AIMD;
+}
+
+/// Reaps deallocated actor references from the underlying lookup table.
+pub struct ActorRefReaper {
+    scheduled: bool,
+    strategy: UpdateStrategy,
+}
+
+/// Defines an interval update strategy.
+pub struct UpdateStrategy {
+    curr: u64,
+    incr: u64,
+    decr: u64,
+    min: u64,
+    max: u64,
+    algo: FeedbackAlgorithm,
+}
+
+pub enum FeedbackAlgorithm {
+    AIMD, // additive increase/multiplicative decrease
+    MIMD, // multiplicative increase/multiplicative decrease
+}
+
+impl Default for ActorRefReaper {
+    fn default() -> Self {
+        ActorRefReaper {
+            scheduled: false,
+            strategy: UpdateStrategy::new(
+                defaults::INITIAL_INTERVAL_MS,
+                defaults::MIN_INTERVAL_MS,
+                defaults::MAX_INTERVAL_MS,
+                defaults::ADDITIVE_INCREASE,
+                defaults::MULTIPLICATIVE_DECREASE_DEN,
+                defaults::ALGORITHM,
+            ),
+        }
+    }
+}
+
+impl ActorRefReaper {
+    pub fn new(
+        initial_interval: u64,
+        min: u64,
+        max: u64,
+        incr: u64,
+        decr: u64,
+        algo: FeedbackAlgorithm,
+    ) -> Self {
+        ActorRefReaper {
+            scheduled: false,
+            strategy: UpdateStrategy::new(initial_interval, min, max, incr, decr, algo),
+        }
+    }
+
+    /// Walks through all stored [ActorRef] entries and removes
+    /// the ones which have been deallocated, returning the # of removed instances.
+    pub fn run<T: ActorLookup>(&self, table: &Arc<ArcCell<T>>) -> usize {
+        let new_table = table.get();
+        let mut new_table = (*new_table).clone();
+        let removed = new_table.cleanup();
+        table.set(Arc::new(new_table));
+        removed
+    }
+
+    pub fn strategy(&self) -> &UpdateStrategy {
+        &self.strategy
+    }
+
+    pub fn strategy_mut(&mut self) -> &mut UpdateStrategy {
+        &mut self.strategy
+    }
+
+    pub fn schedule(&mut self) {
+        self.scheduled = true;
+    }
+
+    pub fn is_scheduled(&self) -> bool {
+        self.scheduled
+    }
+}
+
+impl UpdateStrategy {
+    pub fn new(
+        curr: u64,
+        min: u64,
+        max: u64,
+        incr: u64,
+        decr: u64,
+        algo: FeedbackAlgorithm,
+    ) -> Self {
+        UpdateStrategy {
+            curr,
+            incr,
+            decr,
+            min,
+            max,
+            algo,
+        }
+    }
+
+    pub fn curr(&self) -> u64 {
+        self.curr
+    }
+
+    /// Increments the current value, clamping it at the configured maximum.
+    /// The updated value is returned.
+    pub fn incr(&mut self) -> u64 {
+        use self::FeedbackAlgorithm::*;
+        self.curr = match self.algo {
+            AIMD => self.curr + self.incr,
+            MIMD => self.curr * self.incr,
+        }.min(self.max);
+        self.curr
+    }
+
+    /// Decrements the current value, clamping it at the configured minimum.
+    /// The updated value is returned.
+    pub fn decr(&mut self) -> u64 {
+        use self::FeedbackAlgorithm::*;
+        self.curr = match self.algo {
+            AIMD | MIMD => self.curr / self.decr,
+        }.max(self.min);
+        self.curr
+    }
+}

--- a/core/src/dispatch/lookup/mod.rs
+++ b/core/src/dispatch/lookup/mod.rs
@@ -13,7 +13,9 @@ use std::collections::HashMap;
 use trie::SequenceTrie;
 use uuid::Uuid;
 
-pub trait ActorLookup {
+pub mod gc;
+
+pub trait ActorLookup: Clone {
     /// Inserts or replaces the `path` in the lookup structure.
     /// If an entry already exists, it is removed and returned before being replaced.
     fn insert(&mut self, actor: ActorRef, path: PathResolvable) -> Option<ActorRef>;
@@ -52,6 +54,11 @@ pub trait ActorLookup {
 
     /// Removes the value at the given key, returning `true` if it existed.
     fn remove_by_named_path(&mut self, path: &Vec<String>) -> bool;
+
+    /// Performs cleanup on this lookup table, returning how many entries were affected.
+    fn cleanup(&mut self) -> usize {
+        0
+    }
 }
 
 /// Lookup structure for storing and retrieving `ActorRef`s.
@@ -67,6 +74,7 @@ pub trait ActorLookup {
 /// Ex: Broadcasting a message to actors stored on the system path "tcp://127.0.0.1:8080/pongers/*"
 ///
 /// This use case is not currently being utilized, but it may be in the future.
+#[derive(Clone)]
 pub struct ActorStore {
     uuid_map: HashMap<Uuid, ActorRef>,
     name_map: SequenceTrie<String, ActorRef>,
@@ -156,43 +164,80 @@ impl ActorLookup for ActorStore {
         self.name_map.remove(path);
         existed
     }
+
+    fn cleanup(&mut self) -> usize {
+        self.remove_deallocated_entries()
+    }
 }
 
 impl ActorStore {
     fn remove_from_uuid_map(&mut self, actor: &ActorRef) -> usize {
-        let matches: Vec<_> = self.uuid_map
+        let matches: Vec<_> = self
+            .uuid_map
             .iter()
             .filter(|rec| rec.1 == actor)
             .map(|rec| rec.0.clone())
             .collect();
         let existed = matches.len();
-        for m in matches { self.uuid_map.remove(&m); }
+        for m in matches {
+            self.uuid_map.remove(&m);
+        }
         existed
     }
 
     fn remove_from_name_map(&mut self, actor: &ActorRef) -> usize {
-        // FIXME
-        let matches: Vec<_> = self.name_map
+        let matches: Vec<_> = self
+            .name_map
             .iter()
             .filter(|rec| rec.1 == actor)
             .map(|(key, _)| {
                 // Clone the entire Vec<&String> path to be able to remove entries below
                 let mut cl = Vec::new();
-                for k in key { cl.push(k.clone()); }
+                for k in key {
+                    cl.push(k.clone());
+                }
                 cl
             })
             .collect();
         let existed = matches.len();
-        for m in matches { self.name_map.remove(&m); }
+        for m in matches {
+            self.name_map.remove(&m);
+        }
         existed
     }
-}
 
-impl Clone for ActorStore {
-    fn clone(&self) -> Self {
-        ActorStore {
-            uuid_map: self.uuid_map.clone(),
-            name_map: self.name_map.clone(),
+    /// Walks through the `name_map`and `uuid_map`, removing [ActorRef]s which have been
+    /// deallocated by the runtime lifecycle management.
+    fn remove_deallocated_entries(&mut self) -> usize {
+        let mut existed = 0;
+        let matches: Vec<_> = self
+            .name_map
+            .iter()
+            .filter(|&(_, actor)| !actor.can_upgrade_component())
+            .map(|(key, _)| {
+                // Clone the entire Vec<&String> path to be able to remove entries below
+                let mut cl = Vec::new();
+                for k in key {
+                    cl.push(k.clone());
+                }
+                cl
+            })
+            .collect();
+        existed += matches.len();
+        for m in matches {
+            self.name_map.remove(&m);
         }
+
+        let matches: Vec<_> = self
+            .uuid_map
+            .iter()
+            .filter(|&(_, actor)| !actor.can_upgrade_component())
+            .map(|(key, _)| key.clone())
+            .collect();
+        existed += matches.len();
+        for m in matches {
+            self.uuid_map.remove(&m);
+        }
+        existed
     }
 }

--- a/core/src/dispatch/mod.rs
+++ b/core/src/dispatch/mod.rs
@@ -35,6 +35,7 @@ use serialisation::helpers::serialise_msg;
 use serialisation::helpers::serialise_to_recv_envelope;
 use serialisation::Serialisable;
 use std::collections::HashMap;
+use std::time::Duration;
 
 pub(crate) mod lookup;
 mod queue_manager;
@@ -59,6 +60,8 @@ pub struct NetworkDispatcher {
     net_bridge: Option<net::Bridge>,
     /// Management for queuing Frames during network unavailability (conn. init. and MPSC unreadiness)
     queue_manager: Option<QueueManager>,
+    /// Reaper which cleans up deregistered actor references in the actor lookup table
+    reaper: lookup::gc::ActorRefReaper,
 }
 
 // impl NetworkConfig
@@ -77,13 +80,17 @@ impl NetworkDispatcher {
     }
 
     pub fn with_config(cfg: NetworkConfig) -> Self {
+        let lookup = Arc::new(ArcCell::new(Arc::new(ActorStore::new())));
+        let reaper = lookup::gc::ActorRefReaper::default();
+
         NetworkDispatcher {
             ctx: ComponentContext::new(),
             connections: HashMap::new(),
             cfg,
-            lookup: Arc::new(ArcCell::new(Arc::new(ActorStore::new()))),
+            lookup,
             net_bridge: None,
             queue_manager: None,
+            reaper,
         }
     }
 
@@ -346,8 +353,6 @@ impl Dispatcher for NetworkDispatcher {
 
                 match reg {
                     RegistrationEnvelope::Register(actor, path, mut promise) => {
-                        debug!(self.ctx.log(), "Registering actor at {:?}", actor);
-
                         let prev = self.lookup.get();
                         let mut next = (*prev).clone();
                         if next.contains(&path) {
@@ -365,21 +370,14 @@ impl Dispatcher for NetworkDispatcher {
                         if let Some(promise) = promise.take() {
                             promise.fulfill(Ok(()));
                         }
-                    }
-                    RegistrationEnvelope::Deregister(actor_ref) => {
-                        debug!(self.ctx.log(), "Deregistering actor at {:?}", actor_ref);
 
-                        let prev = self.lookup.get();
-                        let mut next = (*prev).clone();
-
-                        let num_removed = next.remove(actor_ref);
-                        if num_removed == 0 {
-                            warn!(self.ctx.log(), "Attempted to remove non-registered ActorRef");
-                        } else {
-                            debug!(self.ctx.log(), "Successfully deregistered {:?} entries", num_removed);
-                            self.lookup.set(Arc::new(next));
+                        if !self.reaper.is_scheduled() {
+                            use timer_manager::Timer;
+                            let first_wakeup = self.reaper.strategy().curr();
+                            self.schedule_once(Duration::from_millis(first_wakeup), |me, _id| {
+                                schedule_reaper(me);
+                            });
                         }
-
                     }
                 }
             }
@@ -392,6 +390,34 @@ impl Dispatcher for NetworkDispatcher {
         // TODO get protocol from configuration
         SystemPath::new(Transport::TCP, self.cfg.addr.ip(), self.cfg.addr.port())
     }
+}
+
+fn schedule_reaper(target: &mut NetworkDispatcher) {
+    use timer_manager::Timer;
+
+    if !target.reaper.is_scheduled() {
+        // First time running; mark as sheduled and jump straight to scheduling
+        target.reaper.schedule();
+    } else {
+        // Repeated schedule; prune deallocated ActorRefs and update strategy accordingly
+        let num_reaped = target.reaper.run(&target.lookup);
+        if num_reaped == 0 {
+            // No work done; slow down interval
+            target.reaper.strategy_mut().incr();
+        } else {
+            target.reaper.strategy_mut().decr();
+        }
+    }
+    let next_wakeup = target.reaper.strategy().curr();
+    debug!(
+        target.ctx().log(),
+        "Scheduling reaping at {:?}ms",
+        next_wakeup
+    );
+
+    target.schedule_once(Duration::from_millis(next_wakeup), move |target, _id| {
+        schedule_reaper(target)
+    });
 }
 
 impl Provide<ControlPort> for NetworkDispatcher {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -37,12 +37,12 @@ pub use self::serialisation::*;
 pub use self::timer_manager::*;
 pub use self::utils::*;
 pub use actor_derive::*;
+pub use bytes::Buf;
 pub use component_definition_derive::*;
 pub use slog::{Drain, Fuse, Logger};
 pub use slog_async::Async;
-pub use std::convert::{From, Into};
 pub use std::any::Any;
-pub use bytes::Buf;
+pub use std::convert::{From, Into};
 
 mod actors;
 mod component;

--- a/core/src/messaging/framing.rs
+++ b/core/src/messaging/framing.rs
@@ -41,8 +41,6 @@ impl Serialisable for ActorPath {
                 16, // UuidBytes has 16 bytes
             ),
             ActorPath::Named(ref _np) => {
-                //                let len = np.path_ref().iter().fold(0, |l, s| l + s.len());
-                //                Some(len)
                 unimplemented!();
             }
         }
@@ -58,7 +56,6 @@ impl Serialisable for ActorPath {
             }
             ActorPath::Named(_np) => {
                 unimplemented!();
-//                buf.put_u8(SerIdents::NamedActorPath as u8);
                 // TODO encode length and UTF-8 string of named path
             }
         }

--- a/core/src/messaging/mod.rs
+++ b/core/src/messaging/mod.rs
@@ -31,7 +31,7 @@ pub enum RegistrationError {
 
 /// Envelope representing an actor registration event.
 ///
-/// Used for registering and deregistering an [ActorPath](actors::ActorPath) with a name.
+/// Used for registering an [ActorRef](actors::ActorRef) with a path.
 #[derive(Debug)]
 pub enum RegistrationEnvelope {
     Register(
@@ -39,7 +39,6 @@ pub enum RegistrationEnvelope {
         PathResolvable,
         Option<utils::Promise<Result<(), RegistrationError>>>,
     ),
-    Deregister(ActorRef),
 }
 
 /// Envelopes destined for the dispatcher

--- a/core/src/runtime.rs
+++ b/core/src/runtime.rs
@@ -617,7 +617,10 @@ impl Clone for Box<Scheduler> {
 }
 
 #[derive(Clone)]
-struct ExecutorScheduler<E> where E: Executor + Sync {
+struct ExecutorScheduler<E>
+where
+    E: Executor + Sync,
+{
     exec: E,
 }
 

--- a/core/src/runtime.rs
+++ b/core/src/runtime.rs
@@ -344,7 +344,6 @@ impl KompicsSystem {
         C: ComponentDefinition + 'static,
     {
         c.enqueue_control(ControlEvent::Kill);
-        self.inner.deregister_actor(c.actor_ref());
     }
 
     pub fn kill_notify<C>(&self, c: Arc<Component<C>>) -> Future<()>
@@ -358,7 +357,6 @@ impl KompicsSystem {
             ListenEvent::Destroyed(c.id().clone()),
         ));
         c.enqueue_control(ControlEvent::Kill);
-        self.inner.deregister_actor(c.actor_ref());
         f
     }
 
@@ -562,15 +560,6 @@ impl KompicsRuntime {
         );
         let path = PathResolvable::Alias(alias);
         self.register_by_path(actor_ref, path)
-    }
-
-    fn deregister_actor(&self, actor_ref: ActorRef) -> () {
-        debug!(self.logger(), "Deregistering actor at {:?}", actor_ref);
-        let dispatcher = self.dispatcher_ref();
-        let envelope = MsgEnvelope::Dispatch(DispatchEnvelope::Registration(
-            RegistrationEnvelope::Deregister(actor_ref),
-        ));
-        dispatcher.enqueue(envelope);
     }
 
     fn deadletter_ref(&self) -> ActorRef {

--- a/core/src/serialisation.rs
+++ b/core/src/serialisation.rs
@@ -205,7 +205,6 @@ pub mod helpers {
         mut buffer: B,
         system: &SystemPath,
     ) -> Result<ReceiveEnvelope, SerError> {
-
         if buffer.remaining() < 1 {
             return Err(SerError::InvalidData("Not enough bytes available".into()));
         }

--- a/core/src/timer/thread_timer.rs
+++ b/core/src/timer/thread_timer.rs
@@ -156,7 +156,6 @@ impl TimerThread {
                             }
                             Skip::Millis(ms) if ms > 5 => {
                                 let ms = ms - 5; // balance OS scheduler inaccuracy
-                                println!("Trying to wait {}ms for messages.", ms);
                                 // wait until something is scheduled but max skip
                                 let timeout = Duration::from_millis(ms as u64);
                                 let res = select! {
@@ -164,7 +163,6 @@ impl TimerThread {
                                     recv(channel::after(timeout)) => None,
                                 };
                                 let elap = self.elapsed();
-                                println!("Actually waited {}ms", elap);
                                 let longms = ms as u128;
                                 if elap > longms {
                                     // took longer to get rescheduled than we wanted

--- a/core/src/timer/thread_timer.rs
+++ b/core/src/timer/thread_timer.rs
@@ -74,12 +74,12 @@ impl TimerWithThread {
 
     pub fn shutdown(self) -> Result<(), ThreadTimerError> {
         self.work_queue.send(TimerMsg::Stop);
-         match self.timer_thread.join() {
-                Ok(_) => Ok(()),
-                Err(_) => {
-                    eprintln!("Timer thread panicked!");
-                    Err(ThreadTimerError::CouldNotJoinThread)
-                }       
+        match self.timer_thread.join() {
+            Ok(_) => Ok(()),
+            Err(_) => {
+                eprintln!("Timer thread panicked!");
+                Err(ThreadTimerError::CouldNotJoinThread)
+            }
         }
     }
 
@@ -151,10 +151,8 @@ impl TimerThread {
                                         self.reset(); // since we waited for an arbitrary time and taking a new timestamp incures no error
                                         self.handle_msg(msg)
                                     }
-                                    None => {
-                                        panic!("Timer work_queue unexpectedly shut down!")
-                                    }
-                                }                                
+                                    None => panic!("Timer work_queue unexpectedly shut down!"),
+                                }
                             }
                             Skip::Millis(ms) if ms > 5 => {
                                 let ms = ms - 5; // balance OS scheduler inaccuracy


### PR DESCRIPTION
Supports latest discussions on actor "deregistration" and cleanup.

Deregistration events have been removed: they are unnecessary because the lifecycle management already deallocates the components behind them. 

Instead, an interval-based `ActorRef` "reaper" is started upon first actor registration. This reaper is configurable in its update strategy in terms of:
* initial interval time
* maximum and minimum intervals (in milliseconds)
* separate amounts for increasing and decreasing the current interval
* feedback algorithm (currently Additive Increase/Multiplicative Decrease [AIMD] and MIMD are supported)

Defaults for these values can be found in the submodule `[core] dispatch::lookup::gc::defaults`.

Only manual tests have been done for the new functionality due to the difficulty of testing timing-specific internal state. Suggestions are welcome in this area.