### PR TITLE
Prelude submodule & macro import fix

### DIFF
--- a/core/src/dispatch/mod.rs
+++ b/core/src/dispatch/mod.rs
@@ -65,6 +65,13 @@ pub struct NetworkDispatcher {
 }
 
 // impl NetworkConfig
+impl NetworkConfig {
+    pub fn new(addr: SocketAddr) -> Self {
+        NetworkConfig {
+            addr,
+        }
+    }
+}
 impl Default for NetworkConfig {
     fn default() -> Self {
         NetworkConfig {
@@ -276,7 +283,7 @@ impl NetworkDispatcher {
                             let mut next: Option<ConnectionState> = None;
                             if err.is_disconnected() {
                                 next = Some(ConnectionState::Closed)
-                            }
+                            } // otherwise err.is_full()
 
                             // Consume error and retrieve failed Frame
                             let frame = err.into_inner();

--- a/core/src/dispatch/mod.rs
+++ b/core/src/dispatch/mod.rs
@@ -41,6 +41,7 @@ pub(crate) mod lookup;
 mod queue_manager;
 
 /// Configuration for network dispatcher
+#[derive(Clone)]
 pub struct NetworkConfig {
     addr: SocketAddr,
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -61,7 +61,7 @@ mod timer_manager;
 mod utils;
 
 pub mod prelude {
-    pub use bytes::Buf;
+    pub use bytes::{Buf, BufMut};
 
     pub use ::Any;
     pub use runtime::{KompicsConfig, KompicsSystem};
@@ -86,6 +86,13 @@ pub mod prelude {
         PathResolvable,
         DispatchEnvelope,
         RegistrationError,
+    };
+    pub use serialisation::{
+        SerError,
+        Serialisable,
+        Deserialisable,
+        Deserialiser,
+        Serialiser,
     };
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -60,6 +60,35 @@ pub mod timer;
 mod timer_manager;
 mod utils;
 
+pub mod prelude {
+    pub use bytes::Buf;
+
+    pub use ::Any;
+    pub use runtime::{KompicsConfig, KompicsSystem};
+    pub use component::{
+        ComponentDefinition,
+        Component,
+        ComponentContext,
+        ExecuteResult
+    };
+    pub use component::{Provide, Require};
+    pub use lifecycle::{ControlPort, ControlEvent};
+    pub use actors::{Actor, ActorPath, ActorRef};
+
+    pub use dispatch::{NetworkConfig, NetworkDispatcher};
+    pub use default_components::{
+        CustomComponents,
+        DeadletterBox,
+    };
+    pub use messaging::{
+        MsgEnvelope,
+        ReceiveEnvelope,
+        PathResolvable,
+        DispatchEnvelope,
+        RegistrationError,
+    };
+}
+
 pub type KompicsLogger = Logger<std::sync::Arc<Fuse<Async>>>;
 
 #[cfg(test)]

--- a/macros/component-definition-derive/src/lib.rs
+++ b/macros/component-definition-derive/src/lib.rs
@@ -6,6 +6,7 @@ extern crate quote;
 
 use proc_macro::TokenStream;
 use std::iter::Iterator;
+use std::sync::Arc;
 
 #[proc_macro_derive(ComponentDefinition)]
 pub fn component_definition(input: TokenStream) -> TokenStream {
@@ -119,7 +120,7 @@ fn impl_component_definition(ast: &syn::DeriveInput) -> quote::Tokens {
         };
         quote! {
             impl ComponentDefinition for #name {
-                fn setup(&mut self, self_component: Arc<Component<Self>>) -> () {
+                fn setup(&mut self, self_component: ::std::sync::Arc<Component<Self>>) -> () {
                     #ctx_setup
                     //println!("Setting up ports");
                     #(#port_setup)*


### PR DESCRIPTION
* 1d997b3  ensures the use of `std::sync::Arc` is self-contained in the component definition macro
* fdb1513 _explicitly_ exposes stuff needed to use Kompics, driven by the comments in issue #18 

@Bathtor Please look over the imports in the prelude to verify that they're all required.